### PR TITLE
Adding support for cocoapods

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LogCountry.podspec
+++ b/LogCountry.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name             = 'LogCountry'
+  s.version          = '0.10'
+  s.summary          = 'LogCountry is a simple iOS logging framework written in Swift.'
+
+  s.description      = <<-DESC
+LogCountry is a simple iOS logging framework written in Swift written by Zeke Abuhoff.
+                       DESC
+
+  s.homepage         = 'https://github.com/Baconthorpe/LogCountry'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'Ezekiel Abuhoff' => 'zekeemail@zeke.com' }
+  s.source           = { :git => 'https://github.com/Baconthorpe/LogCountry.git', :tag => s.version.to_s }
+
+  s.ios.deployment_target = '9.0'
+  s.source_files = 'LogCountry/*.{swift,plist,h}'
+
+end


### PR DESCRIPTION
If you plan to support cocoapods, here is a podspec file that will load LogCountry from the v0.10 release. 

Things to be edited in the podspec file: 
- The type of license you want to use (I set to MIT, but you might need something else, check  http://choosealicense.com/ for the one you want)
- Your Email

If accepting, use `pod trunk register <Your Email>` to register, then `pod trunk push LogCountry.podspec` to publish the pod. 
